### PR TITLE
SERVICES-1131 rebranding

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Native Authenticator for JavaScript and TypeScript (written in TypeScript).
 
 ## Distribution
 
-[npm](https://www.npmjs.com/package/@elrondnetwork/native-auth)
+[npm](https://www.npmjs.com/package/@multiversx/mx-sdk-erdjs-legacy-native-auth)
+[npm](https://www.npmjs.com/package/@multiversx/mx-sdk-erdjs-legacy-native-auth)
 
 ## Example
+
 ### Client-side
 
 ```js
@@ -33,7 +35,7 @@ When initializing the client object, an optional config can also be specified wi
   // The endpoint from where the current block information will be fetched upon initialization.
   // The default value points to the mainnet API, but can be overridden to be network-specific
   // or to point to a self-hosted location
-  apiUrl: string = 'https://api.elrond.com';
+  apiUrl: string = 'https://api.multiversx.com';
 
   // TTL that will be encoded in the access token.
   // This value will also be validated by the server and must not be greater than the maximum ttl allowed.
@@ -49,7 +51,6 @@ const server = new NativeAuthServer();
 const result = await server.validate(accessToken);
 ```
 
-
 ### Server-side config
 
 ```js
@@ -57,7 +58,8 @@ const result = await server.validate(accessToken);
   // The endpoint from where the current block information will be fetched upon validation.
   // The default value points to the mainnet API, but can be overridden to be network-specific
   // or to point to a self-hosted location
-  apiUrl: string = 'https://api.elrond.com';
+  apiUrl: string = 'https://api.multiversx.com';
+  apiUrl: string = 'https://api.multiversx.com';
 
   // An optional list of accepted hosts in case the server component must validate the incoming requests
   // by domain
@@ -67,7 +69,8 @@ const result = await server.validate(accessToken);
   // Default: one day (86400 seconds)
   maxExpirySeconds: number = 86400;
 
-  // An optional implementation of the caching interface used for resolving 
+  // An optional implementation of the caching interface used for resolving
+  // An optional implementation of the caching interface used for resolving
   // latest block timestamp and also to validate and provide a block timestamp given a certain block hash.
   // It can be integrated with popular caching mechanisms such as redis
   cache?: NativeAuthCacheInterface;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
-  "name": "@elrondnetwork/native-auth",
-  "version": "0.1.21",
+  "name": "@multiversx/mx-sdk-erdjs-legacy-native-auth",
+  "version": "0.1.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@elrondnetwork/native-auth",
-      "version": "0.1.21",
+      "name": "@multiversx/mx-sdk-erdjs-legacy-native-auth",
+      "version": "0.1.23",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@elrondnetwork/erdjs": "^10.2.7",
-        "@elrondnetwork/erdjs-walletcore": "^1.0.0",
+        "@multiversx/erdjs": "^11.1.3",
+        "@multiversx/erdjs-walletcore": "^2.1.1",
         "axios": "^0.27.2",
         "bech32": "^2.0.0"
       },
@@ -1709,74 +1709,6 @@
         "node": ">=8.9.0"
       }
     },
-    "node_modules/@elrondnetwork/erdjs": {
-      "version": "10.2.7",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdjs/-/erdjs-10.2.7.tgz",
-      "integrity": "sha512-GmoCq7cbWEMj/p0usLAcNf4kdFd2nq0GIcn2Kk4lDmt4PsyxYYb1XydbNKyb8wVNY99+Iy5OsaGLXx3eQom2Vw==",
-      "dependencies": {
-        "@elrondnetwork/transaction-decoder": "0.1.0",
-        "bech32": "1.1.4",
-        "bignumber.js": "9.0.1",
-        "blake2b": "2.1.3",
-        "buffer": "6.0.3",
-        "json-duplicate-key-handle": "1.0.0",
-        "keccak": "3.0.2",
-        "protobufjs": "6.11.3"
-      }
-    },
-    "node_modules/@elrondnetwork/erdjs-walletcore": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdjs-walletcore/-/erdjs-walletcore-1.0.0.tgz",
-      "integrity": "sha512-I+N7rwBs4p9bX6d2Rd9Ck6uwCOsgafDzL9aAaFqwh3NnmEI7JGrXPvFoZxDTOQ9pyd2J9jk4dXS6GAImjd3R8g==",
-      "dependencies": {
-        "@elrondnetwork/bls-wasm": "0.3.3",
-        "bech32": "1.1.4",
-        "bip39": "3.0.2",
-        "blake2b": "2.1.3",
-        "ed25519-hd-key": "1.1.2",
-        "keccak": "3.0.1",
-        "scryptsy": "2.1.0",
-        "tweetnacl": "1.0.3",
-        "uuid": "8.3.2"
-      }
-    },
-    "node_modules/@elrondnetwork/erdjs-walletcore/node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
-    },
-    "node_modules/@elrondnetwork/erdjs/node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
-    },
-    "node_modules/@elrondnetwork/erdjs/node_modules/keccak": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
-      "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@elrondnetwork/transaction-decoder": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/transaction-decoder/-/transaction-decoder-0.1.0.tgz",
-      "integrity": "sha512-R9YSiJCAgdlSzTKBy7/KjohFghmUhZIGDqWt6NGXrf33EN24QB15Q0LgHEW7lXsqsDSF5GpRYetsS7V3jYZQOg==",
-      "dependencies": {
-        "bech32": "^2.0.0"
-      }
-    },
-    "node_modules/@elrondnetwork/transaction-decoder/node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
-    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
@@ -2510,6 +2442,75 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@multiversx/erdjs": {
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@multiversx/erdjs/-/erdjs-11.1.3.tgz",
+      "integrity": "sha512-AJP3Xd6ZK6jAPbW9cAV4oBOtaBGOGBK9fdDCfhdwNBgn/UmblLCxW8AQQMtl4qIFTiAkuvO08Q1xPZExfQvGqQ==",
+      "dependencies": {
+        "@elrondnetwork/transaction-decoder": "1.0.0",
+        "bech32": "1.1.4",
+        "bignumber.js": "9.0.1",
+        "blake2b": "2.1.3",
+        "buffer": "6.0.3",
+        "json-duplicate-key-handle": "1.0.0",
+        "keccak": "3.0.2",
+        "protobufjs": "6.11.3"
+      }
+    },
+    "node_modules/@multiversx/erdjs-walletcore": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@multiversx/erdjs-walletcore/-/erdjs-walletcore-2.1.1.tgz",
+      "integrity": "sha512-08o7jdbe7jsK8XJtdemeERQypb4xujINBtaO3rr5xgUUrHgATZlbqfpxeA+EXfYT9EWHJGyT92Sqf18E8mZT3Q==",
+      "dependencies": {
+        "@elrondnetwork/bls-wasm": "0.3.3",
+        "bech32": "1.1.4",
+        "bip39": "3.0.2",
+        "blake2b": "2.1.3",
+        "ed25519-hd-key": "1.1.2",
+        "ed2curve": "0.3.0",
+        "keccak": "3.0.1",
+        "scryptsy": "2.1.0",
+        "tweetnacl": "1.0.3",
+        "uuid": "8.3.2"
+      }
+    },
+    "node_modules/@multiversx/erdjs-walletcore/node_modules/bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+    },
+    "node_modules/@multiversx/erdjs/node_modules/@elrondnetwork/transaction-decoder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/transaction-decoder/-/transaction-decoder-1.0.0.tgz",
+      "integrity": "sha512-FFUDXffwDNwo4V6Co+S9ur3OPYyAEzwgen7gh7LtQrG7SNPELFHjl+YssABXI8v1+SWmqcrSxervMggAiDDXkg==",
+      "dependencies": {
+        "bech32": "^2.0.0"
+      }
+    },
+    "node_modules/@multiversx/erdjs/node_modules/@elrondnetwork/transaction-decoder/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+    },
+    "node_modules/@multiversx/erdjs/node_modules/bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+    },
+    "node_modules/@multiversx/erdjs/node_modules/keccak": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+      "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3984,6 +3985,14 @@
         "bip39": "3.0.2",
         "create-hmac": "1.1.7",
         "tweetnacl": "1.0.3"
+      }
+    },
+    "node_modules/ed2curve": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.3.0.tgz",
+      "integrity": "sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==",
+      "dependencies": {
+        "tweetnacl": "1.x.x"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -10358,76 +10367,6 @@
         "perf_hooks": "0.0.1"
       }
     },
-    "@elrondnetwork/erdjs": {
-      "version": "10.2.7",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdjs/-/erdjs-10.2.7.tgz",
-      "integrity": "sha512-GmoCq7cbWEMj/p0usLAcNf4kdFd2nq0GIcn2Kk4lDmt4PsyxYYb1XydbNKyb8wVNY99+Iy5OsaGLXx3eQom2Vw==",
-      "requires": {
-        "@elrondnetwork/transaction-decoder": "0.1.0",
-        "bech32": "1.1.4",
-        "bignumber.js": "9.0.1",
-        "blake2b": "2.1.3",
-        "buffer": "6.0.3",
-        "json-duplicate-key-handle": "1.0.0",
-        "keccak": "3.0.2",
-        "protobufjs": "6.11.3"
-      },
-      "dependencies": {
-        "bech32": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-          "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
-        },
-        "keccak": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
-          "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
-          "requires": {
-            "node-addon-api": "^2.0.0",
-            "node-gyp-build": "^4.2.0",
-            "readable-stream": "^3.6.0"
-          }
-        }
-      }
-    },
-    "@elrondnetwork/erdjs-walletcore": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdjs-walletcore/-/erdjs-walletcore-1.0.0.tgz",
-      "integrity": "sha512-I+N7rwBs4p9bX6d2Rd9Ck6uwCOsgafDzL9aAaFqwh3NnmEI7JGrXPvFoZxDTOQ9pyd2J9jk4dXS6GAImjd3R8g==",
-      "requires": {
-        "@elrondnetwork/bls-wasm": "0.3.3",
-        "bech32": "1.1.4",
-        "bip39": "3.0.2",
-        "blake2b": "2.1.3",
-        "ed25519-hd-key": "1.1.2",
-        "keccak": "3.0.1",
-        "scryptsy": "2.1.0",
-        "tweetnacl": "1.0.3",
-        "uuid": "8.3.2"
-      },
-      "dependencies": {
-        "bech32": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-          "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
-        }
-      }
-    },
-    "@elrondnetwork/transaction-decoder": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/transaction-decoder/-/transaction-decoder-0.1.0.tgz",
-      "integrity": "sha512-R9YSiJCAgdlSzTKBy7/KjohFghmUhZIGDqWt6NGXrf33EN24QB15Q0LgHEW7lXsqsDSF5GpRYetsS7V3jYZQOg==",
-      "requires": {
-        "bech32": "^2.0.0"
-      },
-      "dependencies": {
-        "bech32": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-          "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
-        }
-      }
-    },
     "@eslint/eslintrc": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
@@ -10989,6 +10928,77 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@multiversx/erdjs": {
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@multiversx/erdjs/-/erdjs-11.1.3.tgz",
+      "integrity": "sha512-AJP3Xd6ZK6jAPbW9cAV4oBOtaBGOGBK9fdDCfhdwNBgn/UmblLCxW8AQQMtl4qIFTiAkuvO08Q1xPZExfQvGqQ==",
+      "requires": {
+        "@elrondnetwork/transaction-decoder": "1.0.0",
+        "bech32": "1.1.4",
+        "bignumber.js": "9.0.1",
+        "blake2b": "2.1.3",
+        "buffer": "6.0.3",
+        "json-duplicate-key-handle": "1.0.0",
+        "keccak": "3.0.2",
+        "protobufjs": "6.11.3"
+      },
+      "dependencies": {
+        "@elrondnetwork/transaction-decoder": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@elrondnetwork/transaction-decoder/-/transaction-decoder-1.0.0.tgz",
+          "integrity": "sha512-FFUDXffwDNwo4V6Co+S9ur3OPYyAEzwgen7gh7LtQrG7SNPELFHjl+YssABXI8v1+SWmqcrSxervMggAiDDXkg==",
+          "requires": {
+            "bech32": "^2.0.0"
+          },
+          "dependencies": {
+            "bech32": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+              "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+            }
+          }
+        },
+        "bech32": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+          "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+        },
+        "keccak": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+          "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
+          "requires": {
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0",
+            "readable-stream": "^3.6.0"
+          }
+        }
+      }
+    },
+    "@multiversx/erdjs-walletcore": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@multiversx/erdjs-walletcore/-/erdjs-walletcore-2.1.1.tgz",
+      "integrity": "sha512-08o7jdbe7jsK8XJtdemeERQypb4xujINBtaO3rr5xgUUrHgATZlbqfpxeA+EXfYT9EWHJGyT92Sqf18E8mZT3Q==",
+      "requires": {
+        "@elrondnetwork/bls-wasm": "0.3.3",
+        "bech32": "1.1.4",
+        "bip39": "3.0.2",
+        "blake2b": "2.1.3",
+        "ed25519-hd-key": "1.1.2",
+        "ed2curve": "0.3.0",
+        "keccak": "3.0.1",
+        "scryptsy": "2.1.0",
+        "tweetnacl": "1.0.3",
+        "uuid": "8.3.2"
+      },
+      "dependencies": {
+        "bech32": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+          "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -12122,6 +12132,14 @@
         "bip39": "3.0.2",
         "create-hmac": "1.1.7",
         "tweetnacl": "1.0.3"
+      }
+    },
+    "ed2curve": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.3.0.tgz",
+      "integrity": "sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==",
+      "requires": {
+        "tweetnacl": "1.x.x"
       }
     },
     "electron-to-chromium": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@elrondnetwork/native-auth",
-  "version": "0.1.22",
+  "name": "@multiversx/mx-sdk-erdjs-legacy-native-auth",
+  "version": "0.1.23",
   "description": "Native authentication client-side / server-side",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
@@ -15,14 +15,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ElrondNetwork/native-auth.git"
+    "url": "git+https://github.com/multiversx/mx-sdk-erdjs-legacy-native-auth.git"
   },
   "keywords": [
-    "elrond",
+    "multiversx",
     "native",
     "auth"
   ],
-  "author": "ElrondNetwork",
+  "author": "MultiversX",
   "license": "GPL-3.0-or-later",
   "devDependencies": {
     "@babel/core": "^7.17.8",
@@ -40,8 +40,8 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@elrondnetwork/erdjs": "^10.2.7",
-    "@elrondnetwork/erdjs-walletcore": "^1.0.0",
+    "@multiversx/erdjs": "^11.1.3",
+    "@multiversx/erdjs-walletcore": "^2.1.1",
     "axios": "^0.27.2",
     "bech32": "^2.0.0"
   }

--- a/src/entities/native.auth.client.config.ts
+++ b/src/entities/native.auth.client.config.ts
@@ -1,5 +1,5 @@
 export class NativeAuthClientConfig {
   host: string = typeof window !== "undefined" ? window.location.hostname : '';
-  apiUrl: string = 'https://api.elrond.com';
+  apiUrl: string = 'https://api.multiversx.com';
   expirySeconds: number = 60 * 60 * 24;
 }

--- a/src/entities/native.auth.server.config.ts
+++ b/src/entities/native.auth.server.config.ts
@@ -1,7 +1,7 @@
 import { NativeAuthCacheInterface } from "../native.auth.cache.interface";
 
 export class NativeAuthServerConfig {
-  apiUrl: string = 'https://api.elrond.com';
+  apiUrl: string = 'https://api.multiversx.com';
   acceptedHosts: string[] = [];
   maxExpirySeconds: number = 86400;
   cache?: NativeAuthCacheInterface;

--- a/src/native.auth.server.ts
+++ b/src/native.auth.server.ts
@@ -1,21 +1,19 @@
-import axios from "axios";
-import { UserPublicKey, UserVerifier } from "@elrondnetwork/erdjs-walletcore/out";
-import { Address, SignableMessage } from "@elrondnetwork/erdjs/out";
-import { NativeAuthHostNotAcceptedError } from "./entities/errors/native.auth.host.not.accepted.error";
-import { NativeAuthInvalidBlockHashError } from "./entities/errors/native.auth.invalid.block.hash.error";
-import { NativeAuthInvalidSignatureError } from "./entities/errors/native.auth.invalid.signature.error";
-import { NativeAuthTokenExpiredError } from "./entities/errors/native.auth.token.expired.error";
-import { NativeAuthServerConfig } from "./entities/native.auth.server.config";
-import { NativeAuthSignature } from "./native.auth.signature";
-import { NativeAuthResult as NativeAuthValidateResult } from "./entities/native.auth.validate.result";
-import { NativeAuthDecoded } from "./entities/native.auth.decoded";
+import axios from 'axios';
+import { UserPublicKey, UserVerifier } from '@multiversx/erdjs-walletcore';
+import { SignableMessage, Address } from '@multiversx/erdjs';
+import { NativeAuthHostNotAcceptedError } from './entities/errors/native.auth.host.not.accepted.error';
+import { NativeAuthInvalidBlockHashError } from './entities/errors/native.auth.invalid.block.hash.error';
+import { NativeAuthInvalidSignatureError } from './entities/errors/native.auth.invalid.signature.error';
+import { NativeAuthTokenExpiredError } from './entities/errors/native.auth.token.expired.error';
+import { NativeAuthServerConfig } from './entities/native.auth.server.config';
+import { NativeAuthSignature } from './native.auth.signature';
+import { NativeAuthResult as NativeAuthValidateResult } from './entities/native.auth.validate.result';
+import { NativeAuthDecoded } from './entities/native.auth.decoded';
 
 export class NativeAuthServer {
   config: NativeAuthServerConfig;
 
-  constructor(
-    config?: Partial<NativeAuthServerConfig>,
-  ) {
+  constructor(config?: Partial<NativeAuthServerConfig>) {
     this.config = Object.assign(new NativeAuthServerConfig(), config);
   }
 
@@ -72,6 +70,8 @@ export class NativeAuthServer {
       message: Buffer.from(signedMessage, 'utf8'),
       signature: new NativeAuthSignature(decoded.signature),
     });
+
+    console.log(`signedMessage ${signedMessage}`);
 
     const publicKey = new UserPublicKey(
       Address.fromString(decoded.address).pubkey(),

--- a/src/native.auth.signature.ts
+++ b/src/native.auth.signature.ts
@@ -1,7 +1,7 @@
-import { ISignature } from "@elrondnetwork/erdjs/out";
+import { ISignature } from "@multiversx/erdjs";
 
 export class NativeAuthSignature implements ISignature {
-  constructor(private readonly signature: string) { }
+  constructor(private readonly signature: string) {}
 
   hex(): string {
     return this.signature;

--- a/test/native.auth.test.ts
+++ b/test/native.auth.test.ts
@@ -1,5 +1,6 @@
-import { UserSigner } from "@elrondnetwork/erdjs-walletcore/out";
-import { SignableMessage } from "@elrondnetwork/erdjs/out";
+
+import { UserSigner } from "@multiversx/erdjs-walletcore";
+import { SignableMessage } from "@multiversx/erdjs";
 import axios from "axios";
 import MockAdapter, { RequestHandler } from "axios-mock-adapter";
 import { NativeAuthHostNotAcceptedError } from "../src/entities/errors/native.auth.host.not.accepted.error";
@@ -13,32 +14,45 @@ import { NativeAuthServer } from "../src/native.auth.server";
 
 describe("Native Auth", () => {
   let mock: MockAdapter;
-  const ADDRESS = 'erd13rrn3fwjds8r5260n6q3pd2qa6wqkudrhczh26d957c0edyzermshds0k8';
-  const HOST = 'elrond.com';
-  const SIGNATURE = '4b445f287663b868e269aa0532c9fd73acb37cfd45f46e33995777e68e5ecc15d97318d9af09c4102f9b40ecf347a75e2d2e81acbcc3c72ae32fcf659c2acd0e';
-  const BLOCK_HASH = 'b3d07565293fd5684c97d2b96eb862d124fd698678f3f95b2515ed07178a27b4';
+  const ADDRESS =
+    'erd1qnk2vmuqywfqtdnkmauvpm8ls0xh00k8xeupuaf6cm6cd4rx89qqz0ppgl';
+  const HOST = 'api.multiversx.com';
+  const SIGNATURE =
+    'efbe8fd1132942a628e5681535d6e1c7b53344568520cff2f504123dfb7bfc2ef551966d4cf5dcd2cabbea690bc542c7de0731d35fbafaee3c32e09475edb105';
+  const BLOCK_HASH =
+    'fbd590696859076769bbf9127e8ca1a4ee0886ac0a8b7c423935be649ca6cfb1';
   const TTL = 86400;
-  const TOKEN = `ZWxyb25kLmNvbQ.${BLOCK_HASH}.${TTL}.e30`;
-  const ACCESS_TOKEN = 'ZXJkMTNycm4zZndqZHM4cjUyNjBuNnEzcGQycWE2d3FrdWRyaGN6aDI2ZDk1N2MwZWR5emVybXNoZHMwazg.Wld4eWIyNWtMbU52YlEuYjNkMDc1NjUyOTNmZDU2ODRjOTdkMmI5NmViODYyZDEyNGZkNjk4Njc4ZjNmOTViMjUxNWVkMDcxNzhhMjdiNC44NjQwMC5lMzA.4b445f287663b868e269aa0532c9fd73acb37cfd45f46e33995777e68e5ecc15d97318d9af09c4102f9b40ecf347a75e2d2e81acbcc3c72ae32fcf659c2acd0e';
-  const BLOCK_TIMESTAMP = 1653068466;
+  const TOKEN = `YXBpLm11bHRpdmVyc3guY29t.${BLOCK_HASH}.${TTL}.e30`;
+  const ACCESS_TOKEN =
+    'ZXJkMXFuazJ2bXVxeXdmcXRkbmttYXV2cG04bHMweGgwMGs4eGV1cHVhZjZjbTZjZDRyeDg5cXF6MHBwZ2w.WVhCcExtMTFiSFJwZG1WeWMzZ3VZMjl0LmZiZDU5MDY5Njg1OTA3Njc2OWJiZjkxMjdlOGNhMWE0ZWUwODg2YWMwYThiN2M0MjM5MzViZTY0OWNhNmNmYjEuODY0MDAuZTMw.efbe8fd1132942a628e5681535d6e1c7b53344568520cff2f504123dfb7bfc2ef551966d4cf5dcd2cabbea690bc542c7de0731d35fbafaee3c32e09475edb105';
+  const BLOCK_TIMESTAMP = 1673350224;
 
   const PEM_KEY = `-----BEGIN PRIVATE KEY for erd1qnk2vmuqywfqtdnkmauvpm8ls0xh00k8xeupuaf6cm6cd4rx89qqz0ppgl-----
   ODY1NmI0ZjMzYTRjOTY0MGI3MTFiY2E4NDUzODNiMDZiNjczMjAzNjk2ZjYxYjMy
   N2E5MDY3ODdlNWExODg1NjA0ZWNhNjZmODAyMzkyMDViNjc2ZGY3OGMwZWNmZjgz
   Y2Q3N2JlYzczNjc4MWU3NTNhYzZmNTg2ZDQ2NjM5NDA=
   -----END PRIVATE KEY for erd1qnk2vmuqywfqtdnkmauvpm8ls0xh00k8xeupuaf6cm6cd4rx89qqz0ppgl-----`;
-  const PEM_ADDRESS = 'erd1qnk2vmuqywfqtdnkmauvpm8ls0xh00k8xeupuaf6cm6cd4rx89qqz0ppgl';
+  const PEM_ADDRESS =
+    'erd1qnk2vmuqywfqtdnkmauvpm8ls0xh00k8xeupuaf6cm6cd4rx89qqz0ppgl';
 
   const onLatestBlockHashGet = function (mock: MockAdapter): RequestHandler {
-    return mock.onGet('https://api.elrond.com/blocks?size=1&fields=hash');
+    return mock.onGet('https://api.multiversx.com/blocks?size=1&fields=hash');
   };
 
-  const onLatestBlockTimestampGet = function (mock: MockAdapter): RequestHandler {
-    return mock.onGet('https://api.elrond.com/blocks?size=1&fields=timestamp');
+  const onLatestBlockTimestampGet = function (
+    mock: MockAdapter
+  ): RequestHandler {
+    return mock.onGet(
+      'https://api.multiversx.com/blocks?size=1&fields=timestamp'
+    );
   };
 
-  const onSpecificBlockTimestampGet = function (mock: MockAdapter): RequestHandler {
-    return mock.onGet(`https://api.elrond.com/blocks/${BLOCK_HASH}?extract=timestamp`);
+  const onSpecificBlockTimestampGet = function (
+    mock: MockAdapter
+  ): RequestHandler {
+    return mock.onGet(
+      `https://api.multiversx.com/blocks/${BLOCK_HASH}?extract=timestamp`
+    );
   };
 
   beforeAll(() => {


### PR DESCRIPTION
Purpose: rebranding

PS: 
there's currently a problem with the tests or with the server logic

5 tests are failing when running `npm run test` because `{}` is inserted at the end of the signedMessage:
`erd1qnk2vmuqywfqtdnkmauvpm8ls0xh00k8xeupuaf6cm6cd4rx89qqz0ppglYXBpLm11bHRpdmVyc3guY29t.fbd590696859076769bbf9127e8ca1a4ee0886ac0a8b7c423935be649ca6cfb1.86400.e30{}`

If I remove `{}` from:
- native.auth.server.ts / line 67 /     const signedMessage = `${decoded.address}${decoded.body}{}`;
- native.auth.ts / lines 286 & 324 / const messageToSign = `${PEM_ADDRESS}${signableToken}{}`;
All the tests will pass
